### PR TITLE
CI: stable ONNX normalizer + scoped hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,40 @@
+exclude: "^(mlruns/|artifacts/|datasets/|docs/perf/baselines/)"
+
 repos:
-- repo: local
-  hooks:
-  - id: onnx-contracts
-    name: onnx-contracts
-    entry: python scripts/inference/check_onnx_contracts.py --config docs/perf/budgets.yaml --outdir artifacts/perf
-    language: system
-    pass_filenames: false
-    stages: [pre-commit]
-- repo: local
-  hooks:
-  - id: onnx-normalize
-    name: onnx-normalize
-    entry: python scripts/inference/normalize_onnx.py
-    language: system
-    files: ^artifacts/onnx/.*\.onnx$
-    pass_filenames: true
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+        files: "^(?!mlruns/|artifacts/|datasets/|docs/perf/baselines/).*"
+      - id: end-of-file-fixer
+        files: "^(?!mlruns/|artifacts/|datasets/|docs/perf/baselines/).*"
+
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        files: ^scripts/inference/
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.7
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^scripts/inference/
+
+  - repo: local
+    hooks:
+      - id: onnx-contracts
+        name: onnx-contracts
+        entry: python scripts/inference/check_onnx_contracts.py --config docs/perf/budgets.yaml --outdir artifacts/perf
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: onnx-normalize
+        name: onnx-normalize
+        entry: python scripts/inference/normalize_onnx.py artifacts/onnx
+        language: system
+        pass_filenames: false
+        files: ^artifacts/onnx/.*\.onnx$
+        stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,19 +2,17 @@
 line-length = 100
 target-version = ["py310"]
 
-[tool.isort]
-profile = "black"
+[tool.pytest.ini_options]
+testpaths = ["training/tests"]
+pythonpath = ["training", "sim"]
 
 [tool.ruff]
 line-length = 100
 target-version = "py310"
-extend-exclude = ["datasets", "sim/logs", "training/runs"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B"]
-ignore = ["E203"]  # Black compatibility
+ignore = ["E203"]
 
-[tool.pytest.ini_options]
-testpaths = ["training/tests"]
-pythonpath = ["training","sim"]
-addopts = "-q"
+[tool.ruff.lint.per-file-ignores]
+"scripts/inference/*.py" = ["E501"]  # allow long prints in CLI scripts

--- a/scripts/inference/normalize_onnx.py
+++ b/scripts/inference/normalize_onnx.py
@@ -1,18 +1,114 @@
 #!/usr/bin/env python
-import sys, onnx
+from __future__ import annotations
+
+import sys
 from pathlib import Path
 
-def fix(p: Path):
-    m = onnx.load(p.as_posix())
-    m.ir_version = 10
-    for imp in m.opset_import:
-        if imp.domain in ("", "ai.onnx"):
-            imp.version = 13
-    onnx.checker.check_model(m)
-    onnx.save(m, p.as_posix())
-    print(f"[normalized] {p}")
+import onnx
 
-paths = [Path(x) for x in sys.argv[1:]]
-for p in paths:
-    if p.is_file():
-        fix(p)
+# Reduce ops that, at higher opsets, may accept "axes" as a second *input* tensor
+REDUCE_OPS = {
+    "ReduceMean",
+    "ReduceSum",
+    "ReduceProd",
+    "ReduceMin",
+    "ReduceMax",
+    "ReduceL1",
+    "ReduceL2",
+    "ReduceLogSum",
+    "ReduceLogSumExp",
+    "ReduceSumSquare",
+}
+
+
+def needs_opset18_for_axes_input(model: onnx.ModelProto) -> bool:
+    """Return True iff any Reduce* node supplies axes as a tensor input (input[1])."""
+    for n in model.graph.node:
+        if n.op_type in REDUCE_OPS and len(n.input) >= 2 and n.input[1]:
+            return True
+    return False
+
+
+def current_ai_onnx_opset(model: onnx.ModelProto) -> int:
+    """Get the numeric opset for the default (ai.onnx) domain."""
+    cur = 0
+    for imp in model.opset_import:
+        if imp.domain in ("", "ai.onnx"):
+            try:
+                cur = max(cur, int(imp.version))
+            except Exception:
+                pass
+    return cur
+
+
+def set_ai_onnx_opset_at_least(model: onnx.ModelProto, minimum: int) -> bool:
+    """
+    Ensure the default (ai.onnx) opset is >= minimum.
+    Preserve other domains. Return True if modified.
+    """
+    cur = current_ai_onnx_opset(model)
+    target = max(cur, minimum)
+    if target == cur:
+        return False
+
+    new_imports: list[onnx.OperatorSetIdProto] = []
+    replaced_ai = False
+    for imp in model.opset_import:
+        if imp.domain in ("", "ai.onnx"):
+            if not replaced_ai:
+                new_imports.append(onnx.helper.make_operatorsetid("", target))
+                replaced_ai = True
+            # skip duplicate ai.onnx entries
+        else:
+            new_imports.append(imp)
+
+    if not replaced_ai:
+        new_imports.append(onnx.helper.make_operatorsetid("", target))
+
+    del model.opset_import[:]
+    model.opset_import.extend(new_imports)
+    return True
+
+
+def normalize_one(p: Path) -> None:
+    # Skip scratch promotion files by convention
+    if p.name.startswith("_promote_"):
+        print(f"[skip] {p} (promotion scratch)")
+        return
+
+    m = onnx.load(p.as_posix())
+
+    # Base requirement: opset >= 13 for broad ORT compatibility
+    required = 13
+    # If any Reduce* uses axes as an input tensor, require opset >= 18
+    if needs_opset18_for_axes_input(m):
+        required = 18
+
+    changed = set_ai_onnx_opset_at_least(m, required)
+
+    # Do NOT force IR downgrades; keep whatever IR the model already has.
+    # Validate before saving so schema mismatches fail early.
+    onnx.checker.check_model(m)
+
+    if changed:
+        onnx.save(m, p.as_posix())
+        print(f"[normalized] {p} opset -> {required}")
+    else:
+        print(f"[ok] {p} opset={current_ai_onnx_opset(m)}")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("usage: normalize_onnx.py <model.onnx | directory>", file=sys.stderr)
+        sys.exit(2)
+
+    root = Path(sys.argv[1])
+    if root.is_file():
+        normalize_one(root)
+    else:
+        for f in sorted(root.rglob("*.onnx")):
+            normalize_one(f)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Normalizer bumps ai.onnx opset to >=18 when Reduce* has axes input; skips _promote_*; hooks scoped; generated dirs excluded.